### PR TITLE
Fix no status

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,10 @@
     "php-http/mock-client": "^1.5",
     "php-http/message": "^1.0",
     "php-http/guzzle7-adapter": "^1.0"
+  },
+  "config": {
+    "allow-plugins": {
+      "pestphp/pest-plugin": true
+    }
   }
 }

--- a/src/Middleware/Trace.php
+++ b/src/Middleware/Trace.php
@@ -81,13 +81,13 @@ class Trace
             $span->setAttribute('codecov.coverage', $coverage);
         }
 
-        // In the event we can't get a status, we just use code 520.
-        if(!method_exists($response, 'status') {
+        //In the event we can't get a status, we just use code 520.
+        if(!method_exists($response, 'status')) {
             $status = '520';
         } else {
             $status = $response->status();
         }
-           
+
         $this->setSpanStatus($span, $status);
         $this->addConfiguredTags($span, $request, $response);
 

--- a/src/Middleware/Trace.php
+++ b/src/Middleware/Trace.php
@@ -89,7 +89,7 @@ class Trace
         }
 
         $this->setSpanStatus($span, $status);
-        $this->addConfiguredTags($span, $request, $response);
+        $this->addConfiguredTags($span, $request, $response, $status);
 
         $uri = $request->route() ? $request->route()->uri() : null;
         if($uri) {
@@ -112,9 +112,9 @@ class Trace
         }
     }
 
-    private function addConfiguredTags(Span $span, Request $request, $response)
+    private function addConfiguredTags(Span $span, Request $request, $response, $status)
     {
-        $span->setAttribute('http.status_code', $response->status() ?? 'not passed');
+        $span->setAttribute('http.status_code', $status ?? 'not passed');
         $span->setAttribute('http.method', $request->method()) ?? 'not passed';
         $span->setAttribute('http.host', $request->root() ?? 'not passed');
         $span->setAttribute('http.target', '/'.$request->path() ?? 'not passed');

--- a/src/Middleware/Trace.php
+++ b/src/Middleware/Trace.php
@@ -81,7 +81,14 @@ class Trace
             $span->setAttribute('codecov.coverage', $coverage);
         }
 
-        $this->setSpanStatus($span, $response->status());
+        // In the event we can't get a status, we just use code 520.
+        if(!method_exists($response, 'status') {
+            $status = '520';
+        } else {
+            $status = $response->status();
+        }
+           
+        $this->setSpanStatus($span, $status);
         $this->addConfiguredTags($span, $request, $response);
 
         $uri = $request->route() ? $request->route()->uri() : null;

--- a/tests/Unit/TraceTest.php
+++ b/tests/Unit/TraceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use GuzzleHttp\Exception\RequestException;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use OpenTelemetry\Sdk\Trace;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+use Codecov\LaravelCodecovOpenTelemetry\Middleware\Trace as CodecovTrace;
+
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    $config = testConfig();
+    config($config);
+});
+
+it('properly handles no status response', function(){
+    //mock a binary response. 
+    $response = Mockery::mock(BinaryFileResponse::class);
+
+    $request = Request::create('/example', 'GET');    
+
+    $traceMiddleware = new CodecovTrace;
+
+    $newResp = $traceMiddleware->handle($request, function() use($response) {
+        return $response;
+    });
+
+    //make sure we get our mocked response back and handle() hasn't blown up.
+    expect($newResp)->toBe($response);
+
+});

--- a/tests/Unit/TraceTest.php
+++ b/tests/Unit/TraceTest.php
@@ -53,7 +53,8 @@ it('properly handles no status response', function(){
 it('properly handles a standard response', function(){
     //mock a binary response. 
     $response = Mockery::mock(Response::class)
-    ->shouldReceive('status');
+    ->shouldReceive('status')
+    ->andReturn('200');
 
     $request = Request::create('/example', 'GET');    
 

--- a/tests/Unit/TraceTest.php
+++ b/tests/Unit/TraceTest.php
@@ -1,16 +1,14 @@
 <?php
 
-use GuzzleHttp\Exception\RequestException;
-use Psr\Http\Client\ClientExceptionInterface;
-use Psr\Http\Client\NetworkExceptionInterface;
-use Psr\Http\Client\RequestExceptionInterface;
-
-use GuzzleHttp\Psr7\Request as GuzzleRequest;
-use GuzzleHttp\Psr7\Response as GuzzleResponse;
-use OpenTelemetry\Sdk\Trace;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+use Codecov\LaravelCodecovOpenTelemetry\Codecov\Exporter as CodecovExporter;
+use OpenTelemetry\Sdk\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+
 
 use Codecov\LaravelCodecovOpenTelemetry\Middleware\Trace as CodecovTrace;
 
@@ -28,7 +26,20 @@ it('properly handles no status response', function(){
 
     $request = Request::create('/example', 'GET');    
 
-    $traceMiddleware = new CodecovTrace;
+    $provider = new TracerProvider();
+
+    $exporter = new CodecovExporter(
+        config('laravel_codecov_opentelemetry.service_name'),
+        config('laravel_codecov_opentelemetry.codecov_host'),
+        config('laravel_codecov_opentelemetry.profiling_token')
+    );
+
+    $tracer = $provider
+            ->addSpanProcessor(new SimpleSpanProcessor($exporter))
+            ->getTracer('io.opentelemetry.contrib.php')
+        ;
+
+    $traceMiddleware = new CodecovTrace($tracer);
 
     $newResp = $traceMiddleware->handle($request, function() use($response) {
         return $response;
@@ -38,3 +49,35 @@ it('properly handles no status response', function(){
     expect($newResp)->toBe($response);
 
 });
+
+it('properly handles a standard response', function(){
+    //mock a binary response. 
+    $response = Mockery::mock(Response::class)
+    ->shouldReceive('status');
+
+    $request = Request::create('/example', 'GET');    
+
+    $provider = new TracerProvider();
+
+    $exporter = new CodecovExporter(
+        config('laravel_codecov_opentelemetry.service_name'),
+        config('laravel_codecov_opentelemetry.codecov_host'),
+        config('laravel_codecov_opentelemetry.profiling_token')
+    );
+
+    $tracer = $provider
+            ->addSpanProcessor(new SimpleSpanProcessor($exporter))
+            ->getTracer('io.opentelemetry.contrib.php')
+        ;
+
+    $traceMiddleware = new CodecovTrace($tracer);
+
+    $newResp = $traceMiddleware->handle($request, function() use($response) {
+        return $response;
+    });
+
+    //make sure we get our mocked response back and handle() hasn't blown up.
+    expect($newResp)->toBe($response);
+
+});
+


### PR DESCRIPTION
Fixes an issue that causes the integration to break when the middleware response object has no `status()`. 